### PR TITLE
NPE fix

### DIFF
--- a/src/main/java/com/mediafire/sdk/log/ApiTransaction.java
+++ b/src/main/java/com/mediafire/sdk/log/ApiTransaction.java
@@ -49,7 +49,7 @@ public class ApiTransaction extends MFLog {
     }
 
     public ApiTransaction(PostRequest postRequest, Exception e) {
-        this(postRequest, null, e);
+        this(postRequest, HttpApiResponse.noNetworkResponse(), e);
     }
 
     private ApiTransaction(GetRequest getRequest, HttpApiResponse response, Exception e) {

--- a/src/main/java/com/mediafire/sdk/requests/HttpApiResponse.java
+++ b/src/main/java/com/mediafire/sdk/requests/HttpApiResponse.java
@@ -65,4 +65,8 @@ public class HttpApiResponse {
         result = 31 * result + (mHeaderFields != null ? mHeaderFields.hashCode() : 0);
         return result;
     }
+
+    public static HttpApiResponse noNetworkResponse() {
+        return new HttpApiResponse(-1, null, null);
+    }
 }


### PR DESCRIPTION
not passing null to constructor when there is no HttpApiResponse